### PR TITLE
Enabling simultaneous use of non-lisp interfaces

### DIFF
--- a/lisp_mod/lisp_ipc.h
+++ b/lisp_mod/lisp_ipc.h
@@ -72,7 +72,8 @@ typedef enum {
   LispDaemonRegister = 13,
   LispTrafficMonStart = 14,
   LispSetUDPPorts = 15,
-  LispMaxType = LispSetUDPPorts
+  LispAddLocalEID = 16,
+  LispMaxType = LispAddLocalEID
 } lisp_msgtype_e;
 
 /* 
@@ -115,6 +116,10 @@ typedef struct _lisp_lookup_msg {
 typedef struct _lisp_set_rloc_msg {
   lisp_addr_t addr;
 } lisp_set_rloc_msg_t;
+
+typedef struct _lisp_add_local_eid_msg {
+  lisp_addr_t addr;
+} lisp_add_local_eid_msg_t;
 
 #define ACTION_DROP         0
 #define ACTION_FORWARD      1

--- a/lisp_mod/lisp_ipc_kernel.h
+++ b/lisp_mod/lisp_ipc_kernel.h
@@ -54,6 +54,7 @@ void handle_set_rloc(lisp_cmd_t *cmd, int pid);
 void handle_daemon_register(lisp_cmd_t *cmd, int pid);
 void handle_traffic_mon_start(lisp_cmd_t *cmd, int pid);
 void handle_set_udp_ports(lisp_cmd_t *cmd, int pid);
+void handle_add_eid(lisp_cmd_t *cmd, int pid);
 
 void lisp_netlink_input(struct sk_buff *skb);
 int setup_netlink_socket(void);

--- a/lisp_mod/lisp_mod.c
+++ b/lisp_mod/lisp_mod.c
@@ -104,6 +104,7 @@ int teardown_netfilter_hooks(void)
 static int __init lisp_init (void)
 {
   int result = 0;
+  int i=0; //loop index
 
   printk(KERN_INFO "lisp_mod version %d.%d.%d starting up...\n",
          MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION);
@@ -137,6 +138,12 @@ static int __init lisp_init (void)
   memset(&globals.my_rloc, 0, sizeof(lisp_addr_t));
   globals.my_rloc_af = 0;
   globals.daemonPID = 0;          // 0 indicates unset
+
+  //initializing local eid control
+  globals.num_local_eid=0;
+  for(i=0; i<MAXLOCALEID; i++){
+	  memset(&globals.local_eid_list[i], 0, sizeof(lisp_addr_t));
+  }
 
   return 0;
 }

--- a/lisp_mod/lisp_mod.h
+++ b/lisp_mod/lisp_mod.h
@@ -37,6 +37,7 @@
 #include "linux/netfilter_ipv4.h"
 #include "linux/netlink.h"
 #include "net/net_namespace.h"
+#include "net/ipv6.h"
 #include "tables.h"
 #include "lisp_ipc.h"
 #include "lisp_ipc_kernel.h"
@@ -46,6 +47,7 @@
 #include "lib/patricia/patricia.h"
 
 #define NETLINK_LISP 20  /* XXX Temporary, needs to be in /usr/include/linux/netlink.h */
+#define MAXLOCALEID 10 /*Max number of local EIDs that lispmob handles*/
 
 typedef struct {
   struct sock *nl_socket;       /* Netlink socket */
@@ -58,5 +60,7 @@ typedef struct {
   ushort udp_encap_port;
   ushort udp_control_port;
   int   daemonPID; /* Process ID for lispd */
+  int num_local_eid;
+  lisp_addr_t local_eid_list[MAXLOCALEID];
 } lisp_globals;
 

--- a/lispd/lisp_ipc.h
+++ b/lispd/lisp_ipc.h
@@ -72,7 +72,8 @@ typedef enum {
   LispDaemonRegister = 13,
   LispTrafficMonStart = 14,
   LispSetUDPPorts = 15,
-  LispMaxType = LispSetUDPPorts
+  LispAddLocalEID = 16,
+  LispMaxType = LispAddLocalEID
 } lisp_msgtype_e;
 
 /* 
@@ -115,6 +116,10 @@ typedef struct _lisp_lookup_msg {
 typedef struct _lisp_set_rloc_msg {
   lisp_addr_t addr;
 } lisp_set_rloc_msg_t;
+
+typedef struct _lisp_add_local_eid_msg {
+  lisp_addr_t addr;
+} lisp_add_local_eid_msg_t;
 
 #define ACTION_DROP         0
 #define ACTION_FORWARD      1

--- a/lispd/lispd_iface_mgmt.c
+++ b/lispd/lispd_iface_mgmt.c
@@ -1570,6 +1570,17 @@ int setup_lisp_eid_iface(eid_iface_name, eid_addr, eid_prefix_len)
             syslog(LOG_DAEMON, "route_add (setup_lisp_eid_iface()) failed\n");
             return 0;
         }
+
+        /*
+         * Step 4:
+         * (when required) Inform The Kernel Module about the new EID
+         */
+#ifdef TESTLOCALEID
+        if(!add_local_eid(eid_addr)){
+        	syslog(LOG_DAEMON, "add_local_eid (setup_lisp_eid_iface()) failed\n");
+        	return 0;
+        }
+#endif
         syslog(LOG_DAEMON, "Configured LISP-MN EID interface\n");
         return 1;
 }

--- a/lispd/lispd_ipc.c
+++ b/lispd/lispd_ipc.c
@@ -823,6 +823,39 @@ int set_rloc(lisp_addr_t *my_addr) {
     return(retval);
 } 
 
+/*
+ *  add local EID to kernel module list
+ */
+
+int add_local_eid(lisp_addr_t *my_addr) {
+    int                 retval = 0;
+    size_t              cmd_length = 0;
+    lisp_cmd_t          *cmd;
+    lisp_add_local_eid_msg_t *add_eid_msg;
+
+    cmd_length = sizeof(lisp_cmd_t) + sizeof(lisp_add_local_eid_msg_t);
+
+    if ((cmd = malloc(cmd_length)) == 0) {
+        syslog(LOG_DAEMON, "add_local_eid: malloc failed");
+        return(0);
+    }
+
+    memset(cmd, 0, cmd_length);
+
+    add_eid_msg = (lisp_add_local_eid_msg_t *) CO(cmd, sizeof(lisp_cmd_t));
+
+    cmd->type   = LispAddLocalEID;
+    cmd->length = sizeof(lisp_add_local_eid_msg_t);
+
+    memcpy(&(add_eid_msg->addr), my_addr, sizeof(lisp_addr_t));
+
+    retval = send_command(cmd, cmd_length);
+    syslog(LOG_DAEMON, "Adding local EID to data plane list");
+    free(cmd);
+    return(retval);
+}
+
+
 
 /*
  * Editor modelines


### PR DESCRIPTION
lisp_output(4 or 6) checks whether the src address of a packet is a local EID.
If this is the case the packet is encapsulated as usual, otherwise the packet
is lent to the kernel unmodified.

*to enable we need to add the -DTESTLOCALEID flag to the lispd Makefile
