### PR TITLE
Multihoming

### DIFF
--- a/lisp_mod/lisp_mod.c
+++ b/lisp_mod/lisp_mod.c
@@ -56,17 +56,17 @@ int setup_netfilter_hooks(void)
   globals.netfilter_ops_in.hook     = lisp_input;
   globals.netfilter_ops_in.pf       = PF_INET;
   globals.netfilter_ops_in.hooknum  = NF_INET_PRE_ROUTING;
-  globals.netfilter_ops_in.priority = NF_IP_PRI_FIRST;
+  globals.netfilter_ops_in.priority = NF_IP_PRI_LAST;
 
   globals.netfilter_ops_out.hook    = lisp_output4;
   globals.netfilter_ops_out.pf      = PF_INET;
   globals.netfilter_ops_out.hooknum = NF_INET_LOCAL_OUT;
-  globals.netfilter_ops_out.priority = NF_IP_PRI_FIRST;
+  globals.netfilter_ops_out.priority = NF_IP_PRI_LAST;
 
   globals.netfilter_ops_out6.hook    = lisp_output6;
   globals.netfilter_ops_out6.pf      = PF_INET6;
   globals.netfilter_ops_out6.hooknum = NF_INET_LOCAL_OUT;
-  globals.netfilter_ops_out6.priority = NF_IP_PRI_FIRST;
+  globals.netfilter_ops_out6.priority = NF_IP_PRI_LAST;
     
   globals.multiple_rlocs = 0;
 

--- a/lispconf/lispconf.c
+++ b/lispconf/lispconf.c
@@ -781,11 +781,11 @@ int set_rloc_interface(struct gengetopt_args_info *args_info)
     }
 
     cmd->type = LispSetRLOC;
-    cmd->length = sizeof(lisp_set_rloc_msg_t);
+    cmd->length = sizeof(lisp_set_rloc_msg_t)+ sizeof(rloc_t);
     memset((char *)&rloc_msg, 0, sizeof(lisp_set_rloc_msg_t));
     rloc_msg = (lisp_set_rloc_msg_t *)cmd->val;
-    rloc_msg->addr.address.ip.s_addr = ((struct sockaddr_in *)&ifr.ifr_addr)->sin_addr.s_addr;
-
+    rloc_msg->rlocs->addr.address.ip.s_addr = ((struct sockaddr_in *)&ifr.ifr_addr)->sin_addr.s_addr;
+    rloc_msg->count=1;
     retval = send_command(cmd, cmd_length + sizeof(lisp_cmd_t));
 
     return retval;

--- a/lispd/Makefile
+++ b/lispd/Makefile
@@ -13,7 +13,7 @@
 
 CC		= gcc
 GENGETOPT	= gengetopt
-CFLAGS		+= -Wall -Wno-implicit-function-declaration -g -DDEBUG=3
+CFLAGS		+= -Wall -Wno-implicit-function-declaration -g -DDEBUG=3 -DTESTLOCALEID 
 LIBS		= -lconfuse -lssl -lcrypto -lrt
 INC		= lispd.h
 MAKEFILE	= Makefile

--- a/lispd/lisp_ipc.h
+++ b/lispd/lisp_ipc.h
@@ -113,13 +113,31 @@ typedef struct _lisp_lookup_msg {
   int         all_entries;
 } lisp_lookup_msg_t;
 
+/*#ifndef LISPMOBMH
 typedef struct _lisp_set_rloc_msg {
   lisp_addr_t addr;
 } lisp_set_rloc_msg_t;
 
+#else*/
+/*
+ * RLOC/ifindex mapping. if_index
+ * of zero indicates default/single RLOC
+ */
+typedef struct {
+    lisp_addr_t addr;
+    int if_index;
+} rloc_t;
+
+typedef struct _lisp_set_rloc_msg {
+    int count;
+    rloc_t rlocs[0];
+} lisp_set_rloc_msg_t;
+//#endif
+
 typedef struct _lisp_add_local_eid_msg {
   lisp_addr_t addr;
 } lisp_add_local_eid_msg_t;
+
 
 #define ACTION_DROP         0
 #define ACTION_FORWARD      1

--- a/lispd/lispd.h
+++ b/lispd/lispd.h
@@ -208,6 +208,12 @@
  */
 #define MAX_INET_ADDRSTRLEN INET6_ADDRSTRLEN
 
+//mportoles - have to think wether this is the appropriate place
+/*
+ *  base RT number to use in multihomed policy routing scenarios
+ */
+#define RT_TABLE_LISP_MN            5
+
 /*
  *  lispd database entry
  */
@@ -804,6 +810,10 @@ typedef struct _iface_list_elt {
     int             ready;          // is the iface up and runing?
     int             weight;         // weight & priority associated with the
     int             priority;       // iface
+    int rt_table_num;			// num of the routing table to use for policy routing
+#ifdef LISPMOBMH
+    int if_index;
+#endif
     lisp_addr_t     gateway;        // gateway IP (v4/v6) for this iface
     struct _iface_list_elt *next;
 } iface_list_elt;

--- a/lispd/lispd_config.c
+++ b/lispd/lispd_config.c
@@ -291,6 +291,7 @@ int add_database_mapping(dm)
 
     char *eid_pref_for_add_iface = strdup (eid_prefix);
     lisp_addr_t eid_addr;
+
     memset(&eid_addr, 0, sizeof(lisp_addr_t));
     afi = get_afi(eid_prefix);  
     eid_addr.afi = afi;
@@ -491,6 +492,27 @@ int add_database_mapping(dm)
      */
     if (ctrl_iface == NULL)
         ctrl_iface = find_active_ctrl_iface();
+#ifdef LISPMOBMH
+    /* We need a default rloc (iface) to use. As of now 
+     * we will use the same as the ctrl_iface */
+    if(ctrl_iface != NULL){
+       if (ctrl_iface->AF4_locators->head){
+		  if (ctrl_iface->AF4_locators->head->db_entry) {
+				set_rloc(&(ctrl_iface->AF4_locators->head->db_entry->locator),0);
+				syslog(LOG_INFO,"Mapping RLOC %pI4 to iface %d\n",
+		             &(ctrl_iface->AF4_locators->head->db_entry->locator.address.ip),0);
+			}
+		}
+		else{
+			if (ctrl_iface->AF6_locators->head){
+			  if (ctrl_iface->AF6_locators->head->db_entry) {
+					set_rloc(&(ctrl_iface->AF6_locators->head->db_entry->locator),0);
+				}
+			}
+		}
+    }
+
+#endif
 
     free(eid_pref_for_add_iface);
     free(rloc_ptr);

--- a/lispd/lispd_external.h
+++ b/lispd/lispd_external.h
@@ -60,6 +60,10 @@ extern  int update_iface_list(char *iface_name,
                                 int weight, int priority);
 extern  iface_list_elt *find_active_ctrl_iface ();
 extern  iface_list_elt *search_iface_list(char *iface_name);
+
+
+extern  iface_list_elt *get_first_iface_elt();
+
 extern  void add_item_to_db_entry_list(db_entry_list *dbl, 
                                         db_entry_list_elt *elt);
 extern  int del_item_from_db_entry_list(db_entry_list *dbl, 

--- a/lispd/lispd_iface_list.c
+++ b/lispd/lispd_iface_list.c
@@ -144,6 +144,22 @@ static void dump_iface_list (item)
     }
 }
 
+
+/* get_rt_number
+ * Selects an appropriate routing table number.
+ * As of now is quite naive it goes to the last element in the table
+ * and picks rt_number+1.
+ */
+
+int get_rt_number()
+{
+	iface_list_elt *item=avail_phy_ifaces->tail;
+	if(item)
+		return item->rt_table_num+1;
+	return RT_TABLE_LISP_MN;
+}
+
+
 /*
  * Add/update iface_list_elt with the input parameters
  */
@@ -190,6 +206,11 @@ int update_iface_list (iface_name, eid_prefix,
         memset (elt->AF4_locators, 0, sizeof(db_entry_list));
         memset (elt->AF6_locators, 0, sizeof(db_entry_list));
         elt->iface_name     = strdup(iface_name);
+        //get a table number that we can use
+        elt->rt_table_num	= get_rt_number();
+#ifdef LISPMOBMH
+		elt->if_index = if_nametoindex(iface_name);
+#endif
 
         add_item_to_iface_list (avail_phy_ifaces,elt);
     }
@@ -239,6 +260,15 @@ int update_iface_list (iface_name, eid_prefix,
     dump_iface_list(avail_phy_ifaces->head);
 
     return (1);
+}
+
+
+/* 
+ * Function that allows iterating through interfaces from elsewhere
+ */
+iface_list_elt *get_first_iface_elt(){
+	iface_list_elt  *elt = avail_phy_ifaces->head;
+	return elt;
 }
 
 /*


### PR DESCRIPTION
Added support to multihoming to lispd. 

It can run in two modes: legacy and multi-interface

Compilation options
- Legacy Mode: compile normally
- Multi-interface: add -DLISPMOBMH to CFLAGS in lispd/Makefile

Comments:
- Multi-interface: The control interface receives index 0.
- The Netfilter priority is downgraded from NF_IP_PRI_FIRST to NF_IP_PRI_LAST. This is to ensure that lisp_mod "captures" packets after they have been marked. (the mangle priority is NF_IP_PRI_MANGLE

Basic Functionality:
- The module lisp_mod selects the outgoing interface/rloc based on the value that each packet (sk_buff structure) carries, using the variable "mark".
- lispd assigns a "mark" value to each rloc, 0 being the default rloc.
- As of now lispd assigns as "mark" the ifindex of the interface associated to each rloc (see /sys/class/net/<device_name>/ifindex
- Example of use:
  To force all packets with destination eid 10.0.1.2 use the interface with ifindex 2, we would use the following rule:
  iptables -t MANGLE -I OUTPUT -d 10.0.1.2 -j MARK --set-mark 2
