### PR TITLE
Handling SMRs and Map Registrations in Multihomed nodes

### DIFF
--- a/lispd/lispd.h
+++ b/lispd/lispd.h
@@ -142,6 +142,12 @@
 #define DEFAULT_DATA_CACHE_TTL          60  /* seconds */
 #define DEFAULT_SELECT_TIMEOUT          1000/* ms */
 
+#ifdef LISPMOBMH
+#define DEFAULT_SMR_TIMEOUT           	2  /* MP: Sets the default value to send an SMR
+                                            * after an interface goes down
+                                            */
+#endif
+
 /*
  * LISP Types
  */

--- a/lispd/lispd_external.h
+++ b/lispd/lispd_external.h
@@ -69,6 +69,10 @@ extern  void add_item_to_db_entry_list(db_entry_list *dbl,
 extern  int del_item_from_db_entry_list(db_entry_list *dbl, 
                                         lispd_db_entry_t *elt);
 
+#ifdef LISPMOBMH
+extern  void smr_pitrs(void);
+#endif
+
 
 extern  lispd_database_t  *lispd_database;
 extern  lispd_map_cache_t *lispd_map_cache;
@@ -95,6 +99,9 @@ extern  int         netlink_fd;
 extern  int         v6_receive_fd;
 extern  int         v4_receive_fd;
 extern  int         map_register_timer_fd;
+#ifdef LISPMOBMH
+extern  int			smr_timer_fd;
+#endif
 extern  struct  sockaddr_nl dst_addr;
 extern  struct  sockaddr_nl src_addr;
 extern  nlsock_handle       nlh;

--- a/lispd/lispd_iface_mgmt.c
+++ b/lispd/lispd_iface_mgmt.c
@@ -1164,6 +1164,17 @@ int process_netlink_iface ()
     				}
 #endif
                 }
+
+#ifdef LISPMOBMH
+                if(elt->ready ==0 && ctrl_iface != NULL){
+                    /* Update MAP Register and trigger SMRs.
+                     * In case there are NO active interfaces this is not triggered.
+                     * LSB bits should indicate this (security concerns?)*/
+                    //start timeout to send smr
+                	start_smr_timeout();
+                }
+#endif
+
                 break;
 
             /*    
@@ -1420,6 +1431,10 @@ int process_netlink_iface ()
     				}
 #endif
 				}
+#ifdef LISPMOBMH
+                /*Stop any ongoing SMR clock*/
+                stop_smr_timeout();
+#endif
                 /*
                  * Map register the new RLOC
                  */
@@ -1429,6 +1444,7 @@ int process_netlink_iface ()
                  */
                 sleep (3);
                 syslog(LOG_DAEMON, "process_netlink_iface(): Map register\n");
+
 
                 start_periodic_map_register();
 


### PR DESCRIPTION
The changes focus on considering active/inactive interfaces as follows,
- If just a single interface is used, nothing changes
- With more than one interface running, when an interface falls
  the generation of SMRs is rate limited (sent after a timeout). This is done to prevent excessive
  SMRs in the case a link is going up/down repeatedly.
