### PR TITLE
Added libcap to the software requirements section of README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ To build LISPmob for a standard Linux, you will need:
   * OpenSSL development headers
   * libConfuse
   * gengetopt
+  * libcap v2+
 
 On Debian-derived Linux distributions (including Ubuntu), installing the
 following packages will provide all necessary dependencies:
@@ -90,6 +91,7 @@ following packages will provide all necessary dependencies:
   * 'libssl-dev'
   * 'libconfuse-dev'
   * 'gengetopt'
+  * 'libcap2-bin'
 
 The latest version of the LISPmob source code can be obtained from Github:
 


### PR DESCRIPTION
It appears to be required for 'make install'; I believe it's used to let unprivileged users run lispd.
I put down 'libcap v2+' in the first bullet point list since I think that some distributions, [like Arch Linux](https://www.archlinux.org/packages/core/i686/libcap/), don't call the package 'libcap2', but just libcap and set the version field to something bigger than 2 (or at least that's what it looked like). I didn't go and check if libcap v2.0 is actually good enough, but I'm not sure if that level of granularity is required here.
